### PR TITLE
Reply timeout crash

### DIFF
--- a/src/github.cpp
+++ b/src/github.cpp
@@ -170,7 +170,13 @@ void GitHub::onFinished(const Request& req)
 
 void GitHub::onError(const Request& req, QNetworkReply::NetworkError error)
 {
-  qDebug("network error %d", error);
+  // the only way the request can be aborted is when there's a timeout, which
+  // already logs a message
+  if (error != QNetworkReply::OperationCanceledError) {
+    qCritical().noquote().nospace()
+      << "Github: request for " << req.reply->url().toString() << " failed, "
+      << req.reply->errorString() << " (" << error << ")";
+  }
 
   req.timer->stop();
   req.reply->disconnect();
@@ -185,7 +191,8 @@ void GitHub::onError(const Request& req, QNetworkReply::NetworkError error)
 
 void GitHub::onTimeout(const Request& req)
 {
-  qDebug("timeout");
+  qCritical().noquote().nospace()
+    << "Github: request for " << req.reply->url().toString() << " timed out";
 
   // don't delete the reply, abort will fire the error() handler above
   req.reply->abort();

--- a/src/github.h
+++ b/src/github.h
@@ -67,6 +67,7 @@ public:
 
 public:
   GitHub(const char *clientId = nullptr);
+  ~GitHub();
 
   QJsonArray releases(const Repository &repo);
   void releases(const Repository &repo,
@@ -85,4 +86,9 @@ private:
 
 private:
   QNetworkAccessManager *m_AccessManager;
+
+  // remember the replies that are in flight and delete them in the destructor
+  std::vector<QNetworkReply*> m_replies;
+
+  void deleteReply(QNetworkReply* reply);
 };

--- a/src/github.h
+++ b/src/github.h
@@ -5,6 +5,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
+#include <QTimer>
+#include <QNetworkReply>
 #include <functional>
 
 class GitHubException : public std::exception
@@ -85,10 +87,23 @@ private:
                           const QByteArray &data, bool relative);
 
 private:
+  struct Request
+  {
+    Method method = Method::GET;
+    QByteArray data;
+    std::function<void (const QJsonDocument &)> callback;
+    QTimer* timer = nullptr;
+    QNetworkReply* reply = nullptr;
+  };
+
   QNetworkAccessManager *m_AccessManager;
 
   // remember the replies that are in flight and delete them in the destructor
   std::vector<QNetworkReply*> m_replies;
+
+  void onFinished(const Request& req);
+  void onError(const Request& req, QNetworkReply::NetworkError error);
+  void onTimeout(const Request& req);
 
   void deleteReply(QNetworkReply* reply);
 };


### PR DESCRIPTION
This fixes a crash when:
 1) The update check is started;
 2) MO is restarted by switching instance, for example;
 3) The update check times out.

This happens when a firewall blocks the request and makes it time out. Because the `GitHub` object gets destroyed when restarting MO but the timer is still ticking, it tries to access a `QNetworkReply` in its timeout callback while the parent `QNetworkManager` is dead.

The main fix is to make the timeout timer a child of the `GitHub` object so it gets deleted along with the rest. I've also added the `QNetworkReply` pointers to a vector so they get deleted properly, fixing a small leak.

Along with that, I changed the logging to be more useful and less spammy, reduced the timeout to 10 seconds instead of 30 and moved the code from lambdas to member functions.